### PR TITLE
Update checkout step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
           os: [windows-latest, ubuntu-latest]
     steps:
         - name: Get Source Code
-          uses: actions/checkout@v3
+          uses: actions/checkout@v4
         - name: Restore Dependencies
           run: npm ci
         - name: Build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
           os: [windows-latest, ubuntu-latest]
     steps:
         - name: Get Source Code
-          uses: actions/checkout@v2
+          uses: actions/checkout@v3
         - name: Restore Dependencies
           run: npm ci
         - name: Build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
       pull-requests: write
     steps:
         - name: Get Source Code
-          uses: actions/checkout@v2
+          uses: actions/checkout@v3
         - name: Passing Tests
           id: passing-tests
           uses: ./

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
       pull-requests: write
     steps:
         - name: Get Source Code
-          uses: actions/checkout@v3
+          uses: actions/checkout@v4
         - name: Passing Tests
           id: passing-tests
           uses: ./


### PR DESCRIPTION
Gets rid of the warning:
> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.