### PR TITLE
feat: Update Node version from 20 to 24 in action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -27,5 +27,5 @@ outputs:
   trx-files:
     description: 'list of trx files'
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'dist/index.js'


### PR DESCRIPTION
Resolve #344

> [!NOTE]
> After this update, the following deprecation warning may appear in the workflow logs:
> ```
> [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
> ```
> This is caused by `@opentelemetry/auto-instrumentations-node` internally using the built-in `punycode` module.
> It does not affect functionality.
> For details, see [DEP0040](https://nodejs.org/api/deprecations.html#DEP0040).